### PR TITLE
[DNM] Added support for Initiative followers and hub community users

### DIFF
--- a/examples/Working with Community.ipynb
+++ b/examples/Working with Community.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arcgishub import hub\n",
+    "\n",
+    "username = 'YOUR_USERNAME'\n",
+    "myHub = hub.Hub(\"https://www.arcgis.com\", username)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://cityxcommunity.maps.arcgis.com'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "corgUrl = myHub.community_orgUrl\n",
+    "corgUrl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<User username:AbbotHutchinson>,\n",
+       " <User username:adam.ajm9>,\n",
+       " <User username:arcgishub3>,\n",
+       " <User username:asa_census>,\n",
+       " <User username:aturner_cityxcommunity>,\n",
+       " <User username:bencschmitz1>,\n",
+       " <User username:canserina>,\n",
+       " <User username:cityofx_community_admin>,\n",
+       " <User username:connormc6>,\n",
+       " <User username:contactklara>,\n",
+       " <User username:courtney_community>,\n",
+       " <User username:CurranDurham>,\n",
+       " <User username:CynthiaMccarty>,\n",
+       " <User username:DaleStone>,\n",
+       " <User username:DamianGlass>,\n",
+       " <User username:DariaWallace>,\n",
+       " <User username:DariaWallace4607>,\n",
+       " <User username:DennisFulton>,\n",
+       " <User username:DerekFerguson>,\n",
+       " <User username:DillonMoran>,\n",
+       " <User username:DonnaMaddox>,\n",
+       " <User username:EaganRiggs>,\n",
+       " <User username:ElmoBlack>,\n",
+       " <User username:FullerHutchinson8110>,\n",
+       " <User username:GabrielFisher>,\n",
+       " <User username:GabrielHarding>,\n",
+       " <User username:GalvinWheeler>,\n",
+       " <User username:GavinBuck>,\n",
+       " <User username:GayWalsh9982>,\n",
+       " <User username:GradyBooker>,\n",
+       " <User username:HadassahNieves>,\n",
+       " <User username:HasadMullen>,\n",
+       " <User username:HavivaDavid>,\n",
+       " <User username:HeidiHawkins>,\n",
+       " <User username:HiramColon9186>,\n",
+       " <User username:HollyJimenez>,\n",
+       " <User username:HopGilbert9955>,\n",
+       " <User username:HopTownsend>,\n",
+       " <User username:HowardBauer3790>,\n",
+       " <User username:hubcommember>,\n",
+       " <User username:idtdocuments>,\n",
+       " <User username:IonaAyala>,\n",
+       " <User username:IrisLindsey>,\n",
+       " <User username:IrisMoon>,\n",
+       " <User username:IvanSwanson>,\n",
+       " <User username:IvorThomas>,\n",
+       " <User username:JacobBennett3154>,\n",
+       " <User username:JacobBennett3292>,\n",
+       " <User username:jagravois51>,\n",
+       " <User username:jagravois_community>,\n",
+       " <User username:JamalBray>,\n",
+       " <User username:JanaSantana>,\n",
+       " <User username:JasonMccall9290>,\n",
+       " <User username:JaymeBradshaw>,\n",
+       " <User username:jfan1998>,\n",
+       " <User username:JoelleMccall5910>,\n",
+       " <User username:JonahBerry>,\n",
+       " <User username:JordanDavidson6126>,\n",
+       " <User username:JordenMcintosh>,\n",
+       " <User username:JudahMarquez7332>,\n",
+       " <User username:KaneWiley2980>,\n",
+       " <User username:KareemNorman8339>,\n",
+       " <User username:KarinaShelton1667>,\n",
+       " <User username:KasimirHodges9291>,\n",
+       " <User username:katie.w.milne27>,\n",
+       " <User username:KatoWilliams8206>,\n",
+       " <User username:KellieHuff1258>,\n",
+       " <User username:KelsieKnowles>,\n",
+       " <User username:KennedyHammond>,\n",
+       " <User username:KennethCraft6013>,\n",
+       " <User username:KimberleyShepherd>,\n",
+       " <User username:krithicakantharaj2>,\n",
+       " <User username:LatifahZamora4580>,\n",
+       " <User username:LeandraMiddleton4369>,\n",
+       " <User username:LeilaniPatton>,\n",
+       " <User username:LillianFloyd1444>,\n",
+       " <User username:LinusHardin4050>,\n",
+       " <User username:LionelRios>,\n",
+       " <User username:LucianGonzalez>,\n",
+       " <User username:LukeHicks9257>,\n",
+       " <User username:LydiaAllen>,\n",
+       " <User username:LynnHuber7338>,\n",
+       " <User username:LynnHuber9199>,\n",
+       " <User username:LynnPeterson>,\n",
+       " <User username:MacKensieCobb4197>,\n",
+       " <User username:MadesonNoel5596>,\n",
+       " <User username:MadisonCopeland1570>,\n",
+       " <User username:MadisonCopeland9747>,\n",
+       " <User username:MaggyHouse9469>,\n",
+       " <User username:MaggyOwen>,\n",
+       " <User username:MalloryBailey2737>,\n",
+       " <User username:markiepooho62>,\n",
+       " <User username:MartinaRoy7885>,\n",
+       " <User username:MartinMarquez3272>,\n",
+       " <User username:marvin2>,\n",
+       " <User username:MaryamFrye3933>,\n",
+       " <User username:MaryVincent>,\n",
+       " <User username:MayMckay7857>,\n",
+       " <User username:mbialousz15>,\n",
+       " <User username:MedgeDixon>]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#myHub.org.users.search(query=\"orgid:\" + myCommunity.community_orgId, outside_org=True)\n",
+    "participants = myHub.community_users()\n",
+    "participants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for user in participants:\n",
+    "    print(user.tags)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'California Census 2020'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "myInitiative = myHub.initiatives.get('d521a1cbf2b14aeeb071a3a994380bd9')\n",
+    "myInitiative.title"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "followers = myInitiative.followers()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'_gis': GIS @ https://cityx.maps.arcgis.com version:7.1,\n",
+      " '_hydrated': False,\n",
+      " '_portal': <arcgis._impl.portalpy.Portal object at 0x1235d0080>,\n",
+      " '_user_id': 'asa_census',\n",
+      " '_workdir': '/var/folders/_n/z57jrjmd351b3mqqmy9ll161_qwmy7/T',\n",
+      " 'created': 1521522577000,\n",
+      " 'culture': None,\n",
+      " 'cultureFormat': None,\n",
+      " 'description': None,\n",
+      " 'firstName': 'Asa',\n",
+      " 'fullName': 'Asa Strong',\n",
+      " 'id': '4d5a70af3357d4a12c98091edc1e35c5',\n",
+      " 'lastName': 'Strong',\n",
+      " 'modified': 1521524002000,\n",
+      " 'provider': None,\n",
+      " 'region': None,\n",
+      " 'tags': ['org:binwXHz9pdkz4Jks',\n",
+      "          'hubRole:participant',\n",
+      "          'hubInitiativeId|d521a1cbf2b14aeeb071a3a994380bd9'],\n",
+      " 'thumbnail': None,\n",
+      " 'units': 'english',\n",
+      " 'username': 'asa_census'}\n",
+      "{'_gis': GIS @ https://cityx.maps.arcgis.com version:7.1,\n",
+      " '_hydrated': False,\n",
+      " '_portal': <arcgis._impl.portalpy.Portal object at 0x1235d0080>,\n",
+      " '_user_id': 'aturner_cityxcommunity',\n",
+      " '_workdir': '/var/folders/_n/z57jrjmd351b3mqqmy9ll161_qwmy7/T',\n",
+      " 'created': 1500488586000,\n",
+      " 'culture': None,\n",
+      " 'cultureFormat': None,\n",
+      " 'description': None,\n",
+      " 'firstName': 'Andrew',\n",
+      " 'fullName': 'Andrew Turner',\n",
+      " 'id': '84eb8fbaafc2dccdf94c64d47d74c4d8',\n",
+      " 'lastName': 'Turner',\n",
+      " 'modified': 1552917950000,\n",
+      " 'provider': None,\n",
+      " 'region': 'WO',\n",
+      " 'tags': ['org:binwXHz9pdkz4Jks',\n",
+      "          'hubRole:participant',\n",
+      "          'Interests:healthy|safe|prosperous|wellrun|sustainable|bicycle|pedestrian|education',\n",
+      "          'Event:082cf12711d744ccb450f85389302f43',\n",
+      "          'Event:f63a22ebd148419497a452a0c36cc5a4',\n",
+      "          'hubEventGroupId|BBpPn9wZu2D6eTNY|c08f08964d8248f19bb154b38dcb108a',\n",
+      "          'Event:2deb3a25f70f4cb3b78e5c69e5c62483',\n",
+      "          'hubInitiativeId|d603b719ba9b4060baa6731b531abf08',\n",
+      "          'hubEventGroupId|BBpPn9wZu2D6eTNY|4be6c7ce80eb49308a2d3202ae850a22',\n",
+      "          'hubInitiativeId|d521a1cbf2b14aeeb071a3a994380bd9',\n",
+      "          'hubEventGroupId|BBpPn9wZu2D6eTNY|afb57ef80e6342df9cf9d4a0ced5e072',\n",
+      "          'hubInitiativeId|aee85947eb3d429d8ef2c553cbf0a888',\n",
+      "          'hubEventGroupId|BBpPn9wZu2D6eTNY|a4789d4bde1c4f15ba6cdb596ca1fa34',\n",
+      "          'hubInitiativeId|e9bc53f888054f9183266dc61d0d3c23',\n",
+      "          'hubEventGroupId|BBpPn9wZu2D6eTNY|66c393af1d4c4cba8b3160ac4a7077e3',\n",
+      "          'hubInitiativeId|e2bd2cac7ef845cf8cb651e1a95d3e90',\n",
+      "          'hubInitiativeId|a3f362c8a10341e8ad21827d3dc8c8d2'],\n",
+      " 'thumbnail': 'Andrew_Turner_2.png',\n",
+      " 'units': 'english',\n",
+      " 'username': 'aturner_cityxcommunity'}\n",
+      "{'_gis': GIS @ https://cityx.maps.arcgis.com version:7.1,\n",
+      " '_hydrated': False,\n",
+      " '_portal': <arcgis._impl.portalpy.Portal object at 0x1235d0080>,\n",
+      " '_user_id': 'krithicakantharaj2',\n",
+      " '_workdir': '/var/folders/_n/z57jrjmd351b3mqqmy9ll161_qwmy7/T',\n",
+      " 'created': 1535639427000,\n",
+      " 'culture': None,\n",
+      " 'cultureFormat': None,\n",
+      " 'description': None,\n",
+      " 'firstName': 'Krithica',\n",
+      " 'fullName': 'Krithica Kantharaj',\n",
+      " 'id': '82ae20f7c62c554db1df439cf41889b4',\n",
+      " 'lastName': 'Kantharaj',\n",
+      " 'modified': 1547729805000,\n",
+      " 'provider': None,\n",
+      " 'region': None,\n",
+      " 'tags': ['org:binwXHz9pdkz4Jks',\n",
+      "          'hubRole:participant',\n",
+      "          'hubInitiativeId|d521a1cbf2b14aeeb071a3a994380bd9',\n",
+      "          'hubInitiativeId|d603b719ba9b4060baa6731b531abf08'],\n",
+      " 'thumbnail': None,\n",
+      " 'units': 'english',\n",
+      " 'username': 'krithicakantharaj2'}\n",
+      "{'_gis': GIS @ https://cityx.maps.arcgis.com version:7.1,\n",
+      " '_hydrated': False,\n",
+      " '_portal': <arcgis._impl.portalpy.Portal object at 0x1235d0080>,\n",
+      " '_user_id': 'wolfe.brenda_volunteer',\n",
+      " '_workdir': '/var/folders/_n/z57jrjmd351b3mqqmy9ll161_qwmy7/T',\n",
+      " 'created': 1517258671000,\n",
+      " 'culture': None,\n",
+      " 'cultureFormat': None,\n",
+      " 'description': None,\n",
+      " 'firstName': 'Brenda',\n",
+      " 'fullName': 'Brenda Wolfe',\n",
+      " 'id': '9443ac9248d5d88f34e9385cd221d6ca',\n",
+      " 'lastName': 'Wolfe',\n",
+      " 'modified': 1539321142000,\n",
+      " 'provider': None,\n",
+      " 'region': None,\n",
+      " 'tags': ['org:binwXHz9pdkz4Jks',\n",
+      "          'hubRole:participant',\n",
+      "          'org:binwXHz9pdkz4Jks',\n",
+      "          'hubRole:participant',\n",
+      "          'hubInitiativeId|d521a1cbf2b14aeeb071a3a994380bd9',\n",
+      "          'hubEventGroupId|BBpPn9wZu2D6eTNY|66c393af1d4c4cba8b3160ac4a7077e3'],\n",
+      " 'thumbnail': None,\n",
+      " 'units': 'english',\n",
+      " 'username': 'wolfe.brenda_volunteer'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pprint import pprint\n",
+    "for person in followers:\n",
+    "    pprint(vars(person))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Changed InitiativeManager and EventManager to reference `hub` instead of `org`. This supports getting more Hub methods for community users, etc.

Todo

- [ ] Get full list of all community members / followers. requires adding pagination
- [ ] Add tests