### PR TITLE
Adding search functionality to Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In order to install Python, install the bundle that comes with the Anaconda dist
 
 Execute the following command in the terminal
 
-``` pip install -e git+https://github.com/esridc/hub-py.git#egg=arcgishub ```
+``` pip install -e git+https://github.com/esri/hub-py.git#egg=arcgishub ```
 
 Once installed, test it by launching an instance of Jupyter Notebook and importing the package
 
@@ -22,7 +22,7 @@ Once installed, test it by launching an instance of Jupyter Notebook and importi
 
 Execute the following command in the terminal
 
-``` pip install -e git+https://github.com/esridc/hub-py.git#egg=arcgishub ```
+``` pip install -e git+https://github.com/esri/hub-py.git#egg=arcgishub ```
 
 Once installed, test it by launching an instance of Jupyter Notebook and importing the package
 
@@ -47,15 +47,15 @@ initiatives = myHub.initiatives.search()
 print(initiatives)
 ```
 
-fetches a list containing all the initiatives within this Hub. Click [here](https://github.com/esridc/hub-py/wiki) for more information and API reference about the functionality supported.
+fetches a list containing all the initiatives within this Hub. Click [here](https://github.com/esri/hub-py/wiki) for more information and API reference about the functionality supported.
 
 ### User Guides
 
-Example notebooks for using this API to work with your Hub are provided in the [examples](https://github.com/esridc/hub-py/tree/master/examples) directory.
+Example notebooks for using this API to work with your Hub are provided in the [examples](https://github.com/esri/hub-py/tree/master/examples) directory.
 
-If you are working with `arcgishub` >=v2.1.0, you will find the above examples and functionality supported in this API under the [For arcgishub](https://github.com/esridc/hub-py/tree/master/examples/For%20arcgishub) folder.
+If you are working with `arcgishub` >=v2.1.0, you will find the above examples and functionality supported in this API under the [For arcgishub](https://github.com/esri/hub-py/tree/master/examples/For%20arcgishub) folder.
 
-Older versions of this API can also be found in the [ArcGIS API for Python](https://developers.arcgis.com/python/). You can find user guides to access Hub using it, under the [For ArcGIS API for Python](https://github.com/esridc/hub-py/tree/master/examples/For%20ArcGIS%20API%20for%20Python) subdirectory.
+Older versions of this API can also be found in the [ArcGIS API for Python](https://developers.arcgis.com/python/). You can find user guides to access Hub using it, under the [For ArcGIS API for Python](https://github.com/esri/hub-py/tree/master/examples/For%20ArcGIS%20API%20for%20Python) subdirectory.
 
 
-We encourage you to provide feedback/issues in implementation, under GitHub [issues](https://github.com/esridc/hub-py/issues) for this repo.
+We encourage you to provide feedback/issues in implementation, under GitHub [issues](https://github.com/esri/hub-py/issues) for this repo.

--- a/arcgishub/hub.py
+++ b/arcgishub/hub.py
@@ -2,7 +2,7 @@ from arcgis.gis import GIS
 from arcgis.features import FeatureLayer
 from arcgis.geocoding import geocode
 from arcgis._impl.common._mixins import PropertyMap
-from arcgishub.sites import SiteManager, PageManager
+from arcgishub.sites import Site, SiteManager, Page, PageManager
 from arcgis.features.enrich_data import enrich_layer
 from datetime import datetime
 from collections import OrderedDict
@@ -51,7 +51,6 @@ class Hub(object):
         self._password = password
         self.url = url
         self.gis = GIS(self.url, self._username, self._password)
-        self.search = self._instance_search
         try:
             self._gis_id = self.gis.properties.id
         except AttributeError:
@@ -144,36 +143,6 @@ class Hub(object):
         except:
             print("Hub does not exist or is inaccessible.")
             raise
-    
-    @staticmethod
-    def search(query='', url=None, username=None, password=None, **kwargs):
-        """
-        Returns a list of hubs based on a search query of GIS content
-        """
-        gis = GIS(url, username, password)
-        item_type = 'Hub *'
-
-        if 'query' in kwargs:
-            if query == None or query == '':
-                query = kwargs['query']
-            del kwargs['query']
-        if 'item_type' in kwargs:
-            if len(kwargs['item_type']) > 0:
-                item_type = kwargs['item_type']
-            del kwargs['item_type']
-
-        return gis.content.search(query=query, item_type=item_type, **kwargs)
-        
-    def _instance_search(self, query='', **kwargs):
-        """
-        Provides search functionality within the organization's hub
-        """
-        item_type = 'Hub *'
-        if 'item_type' in kwargs:
-            if len(kwargs['item_type']) > 0:
-                item_type = kwargs['item_type']
-            del kwargs['item_type']
-        return self.gis.content.search(query=query, item_type=item_type, **kwargs)
 
     @_lazy_property
     def initiatives(self):
@@ -202,6 +171,76 @@ class Hub(object):
         The resource manager for Hub pages. See :class:`~hub.sites.PageManager`.
         """
         return PageManager(self.gis)
+
+    def search(self, title=None, owner=None, created=None, modified=None, tags=None, scope=None):
+        """
+        Provides search functionality within the organization's hub. Results will be organized
+        as either Initiatives  
+        
+       ===============     ====================================================================
+        **Argument**        **Description**
+        ---------------     --------------------------------------------------------------------
+        title               Optional string. Return hub items with provided string in title.
+        ---------------     --------------------------------------------------------------------
+        owner               Optional string. Return hub items owned by a username.
+        ---------------     --------------------------------------------------------------------
+        created             Optional string. Date the hub item was created.
+                            Shown in milliseconds since UNIX epoch.
+        ---------------     --------------------------------------------------------------------
+        modified            Optional string. Date the hub item was last modified.
+                            Shown in milliseconds since UNIX epoch
+        ---------------     --------------------------------------------------------------------
+        tags                Optional string. User-defined tags that describe the hub item.
+        ---------------     --------------------------------------------------------------------
+        scope               Optional string. Defines the scope of search.
+                            Valid values are 'official', 'community' or 'all'.
+        ===============     ====================================================================
+        """
+        resultList = []
+        #Build search query
+        query = 'typekeywords:hub'
+        if title!=None:
+            query += ' AND title:'+title
+        if owner!=None:
+            query += ' AND owner:'+owner
+        if created!=None:
+            query += ' AND created:'+created
+        if modified!=None:
+            query += ' AND modified:'+modified
+        if tags!=None:
+            query += ' AND tags:'+tags
+        
+        #Apply org scope and search
+        if scope is None or self.gis.url=='https://www.arcgis.com':
+            items = self.gis.content.search(query=query, item_type='Hub *', max_items=5000)
+        elif scope.lower()=='official':
+            query += ' AND access:public'
+            _gis = GIS(self.enterprise_org_url)
+            items = _gis.content.search(query=query, item_type='Hub *', max_items=5000)
+        elif scope.lower()=='community':
+            query += ' AND access:public'
+            _gis = GIS(self.community_org_url)
+            items = _gis.content.search(query=query, item_type='Hub *', max_items=5000)
+        elif scope.lower()=='all':
+            items = self.gis.content.search(query=query, item_type='Hub *', outside_org=True, max_items=5000)
+        else:
+            raise Exception("Invalid value for scope")
+
+        for item in items:
+            if "hubInitiative" in item.typeKeywords:
+                resultList.append(Initiative(self, item))
+            elif "hubSite" in item.typeKeywords:
+                resultList.append(Site(self.gis, item))
+            elif "hubPage" in item.typeKeywords:
+                resultList.append(Page(self.gis, item))
+            elif "hubInitiativeTemplate" in item.typeKeywords:
+                # leaving room for an InitiativeTemplate object. 
+                # In the mean time, treat it as an item
+                resultList.append(item)
+            else:
+                # not sure what this is. Will just send back the item
+                resultList.append(item)
+        return resultList
 
 class Initiative(OrderedDict):
     """

--- a/arcgishub/hub.py
+++ b/arcgishub/hub.py
@@ -51,6 +51,7 @@ class Hub(object):
         self._password = password
         self.url = url
         self.gis = GIS(self.url, self._username, self._password)
+        self.search = self._instance_search
         try:
             self._gis_id = self.gis.properties.id
         except AttributeError:
@@ -144,6 +145,36 @@ class Hub(object):
             print("Hub does not exist or is inaccessible.")
             raise
     
+    @staticmethod
+    def search(query='', url=None, username=None, password=None, **kwargs):
+        """
+        Returns a list of hubs based on a search query of GIS content
+        """
+        gis = GIS(url, username, password)
+        item_type = 'Hub *'
+
+        if 'query' in kwargs:
+            if query == None or query == '':
+                query = kwargs['query']
+            del kwargs['query']
+        if 'item_type' in kwargs:
+            if len(kwargs['item_type']) > 0:
+                item_type = kwargs['item_type']
+            del kwargs['item_type']
+
+        return gis.content.search(query=query, item_type=item_type, **kwargs)
+        
+    def _instance_search(self, query='', **kwargs):
+        """
+        Provides search functionality within the organization's hub
+        """
+        item_type = 'Hub *'
+        if 'item_type' in kwargs:
+            if len(kwargs['item_type']) > 0:
+                item_type = kwargs['item_type']
+            del kwargs['item_type']
+        return self.gis.content.search(query=query, item_type=item_type, **kwargs)
+
     @_lazy_property
     def initiatives(self):
         """

--- a/examples/For arcgishub/Accessing events and plotting them on a map.ipynb
+++ b/examples/For arcgishub/Accessing events and plotting them on a map.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Accessign events in your Hub and plotting them on a map"
+    "### Accessing events in your Hub and plotting them on a map"
    ]
   },
   {


### PR DESCRIPTION
Hello,

This PR is to possibly address #5, where you wanted to search for hub items. I wasn't sure how to search for a Hub by itself, since those aren't necessarily exposed as items in an org. What this does is search for hub items like Initiatives, Sites, Pages, etc. and creates a list of those items. I attempted to follow the patterns you set in other searches.

If this wasn't the functionality you were looking for, feel free to dismiss this one.