### PR TITLE
updating subdomain for site

### DIFF
--- a/arcgishub/hub.py
+++ b/arcgishub/hub.py
@@ -98,6 +98,19 @@ class Hub(object):
             return True
         except:
             return False
+
+    @property
+    def _hub_environment(self):
+        """
+        Returns the hub url corresponding to the dev/qa/prod environment.
+        """
+        url = self.gis.url
+        if 'devext' in url:
+            return 'https://hubdev.arcgis.com'
+        elif 'mapsqa' in url:
+            return 'https://hubqa.arcgis.com'
+        else:
+            return 'https://hub.arcgis.com'
             
     @property
     def enterprise_org_id(self):
@@ -590,7 +603,7 @@ class Initiative(OrderedDict):
         return result2
 
 
-    def update(self, initiative_properties=None, data=None, thumbnail=None, metadata=None):
+    def update(self, initiative_properties=None):
         """ Updates the initiative.
 
 
@@ -604,12 +617,6 @@ class Initiative(OrderedDict):
         **Argument**              **Description**
         ---------------------     --------------------------------------------------------------------
         initiative_properties     Required dictionary. See URL below for the keys and values.
-        ---------------------     --------------------------------------------------------------------
-        data                      Optional string. Either a path or URL to the data.
-        ---------------------     --------------------------------------------------------------------
-        thumbnail                 Optional string. Either a path or URL to a thumbnail image.
-        ---------------------     --------------------------------------------------------------------
-        metadata                  Optional string. Either a path or URL to the metadata.
         =====================     ====================================================================
         
         To find the list of applicable options for argument initiative_properties - 
@@ -649,7 +656,7 @@ class Initiative(OrderedDict):
                     _content_group = self._gis.groups.get(self.content_group_id)
                     #Update title for group
                     _content_group.update(title=title+' Content')
-            return self.item.update(_initiative_data, data, thumbnail, metadata)
+            return self.item.update(_initiative_data)
     
 class InitiativeManager(object):
     """
@@ -662,7 +669,7 @@ class InitiativeManager(object):
         self._hub = hub
         self._gis = self._hub.gis
           
-    def add(self, title, description=None, site=None, data=None, thumbnail=None):
+    def add(self, title, description=None, site=None):
         """ 
         Adds a new initiative to the Hub.
         ===============     ====================================================================
@@ -673,10 +680,6 @@ class InitiativeManager(object):
         description         Optional string. 
         ---------------     --------------------------------------------------------------------
         site                Optional Site object. 
-        ---------------     --------------------------------------------------------------------
-        data                Optional string. Either a path or URL to the data.
-        ---------------     --------------------------------------------------------------------
-        thumbnail           Optional string. Either a path or URL to a thumbnail image.
         ===============     ====================================================================
         
         :return:

--- a/arcgishub/hub.py
+++ b/arcgishub/hub.py
@@ -2,7 +2,9 @@ from arcgis.gis import GIS
 from arcgis.features import FeatureLayer
 from arcgis.geocoding import geocode
 from arcgis._impl.common._mixins import PropertyMap
-from arcgishub.sites import SiteManager, PageManager
+from arcgishub.sites import SiteManager, Site, PageManager
+from arcgishub import discussions
+from arcgishub.discussions import ChannelManager, PostManager
 from arcgis.features.enrich_data import enrich_layer
 from datetime import datetime
 from collections import OrderedDict
@@ -92,7 +94,7 @@ class Hub(object):
         Returns True if Hub is enabled on this org
         """
         try:
-            self.gis.properties.subscriptionInfo.hubSettings.enabled
+            self.gis.properties.portalProperties["hub"]["enabled"]
             return True
         except:
             return False
@@ -186,7 +188,10 @@ class Hub(object):
         """
         The resource manager for Hub events. See :class:`~arcgis.apps.hub.EventManager`.
         """
-        return EventManager(self)
+        if self._hub_enabled:
+            return EventManager(self)
+        else:
+            raise Exception("Events is only available with Hub Premium. Please upgrade to Hub Premium to use this feature.")
     
     @_lazy_property
     def sites(self):
@@ -202,6 +207,15 @@ class Hub(object):
         """
         return PageManager(self.gis)
 
+    @_lazy_property
+    def discussions(self):
+        """
+        The resource manager for Hub Discussions.
+        """
+        discussions.posts = PostManager(self)
+        discussions.channels = ChannelManager(self)
+        return discussions
+
 class Initiative(OrderedDict):
     """
     Represents an initiative within a Hub. An Initiative supports 
@@ -215,8 +229,6 @@ class Initiative(OrderedDict):
         self.item = initiativeItem
         self._hub = hub
         self._gis = self._hub.gis
-        #self._gis = gis
-        #self._hub = gis.hub
         try:
             self._initiativedict = self.item.get_data()
             pmap = PropertyMap(self._initiativedict)
@@ -244,13 +256,9 @@ class Initiative(OrderedDict):
     @property
     def description(self):
         """
-        Getter/Setter for the initiative description
+        Returns the initiative description
         """
         return self.item.description
-    
-    @description.setter
-    def description(self, value):
-        self.item.description = value
     
     @property
     def snippet(self):
@@ -278,11 +286,14 @@ class Initiative(OrderedDict):
         return self.item.tags
     
     @property
-    def initiative_url(self):
+    def url(self):
         """
-        Returns the url of the initiative editor
+        Returns the url of the initiative site
         """
-        return self.item.properties['url']
+        try:
+            return self.item.properties["url"]
+        except:
+            return self.item.url
 
     @property 
     def site_id(self):
@@ -299,7 +310,10 @@ class Initiative(OrderedDict):
         """
         Getter/Setter for the url of the initiative site
         """
-        return self.sites.get(self.site_id).url
+        try:
+            return self.item.url
+        except:
+            return self.sites.get(self.site_id).url
 
     @site_url.setter
     def site_url(self, value):
@@ -315,9 +329,16 @@ class Initiative(OrderedDict):
     @property
     def collab_group_id(self):
         """
-        Returns the groupId for the collaboration group
+        Getter/Setter for the groupId for the collaboration group
         """
-        return self.item.properties['collaborationGroupId']
+        try:
+            return self.item.properties['collaborationGroupId']
+        except:
+            return None
+
+    @collab_group_id.setter
+    def collab_group_id(self, value):
+        self.item.properties['collaborationGroupId'] = value
 
     @property
     def followers_group_id(self):
@@ -380,6 +401,7 @@ class Initiative(OrderedDict):
     def add_content(self, items_list):
         """
         Adds a batch of items to the initiative content library.
+        
         =====================     ====================================================================
         **Argument**              **Description**
         ---------------------     --------------------------------------------------------------------
@@ -397,89 +419,130 @@ class Initiative(OrderedDict):
         """
         Deletes the initiative and its site. 
         If unable to delete, raises a RuntimeException.
+        
         :return:
             A bool containing True (for success) or False (for failure). 
+        
         .. code-block:: python
+            
             USAGE EXAMPLE: Delete an initiative successfully
+            
             initiative1 = myHub.initiatives.get('itemId12345')
             initiative1.delete()
+            
             >> True
         """
         if self.item is not None:
-            #Fetch Initiative Collaboration group
-            _collab_group = self._gis.groups.get(self.collab_group_id)
+            #Fetch initiative site
+            _site = self._hub.sites.get(self.site_id)
+            Site.delete(_site)
+            #Fetch and delete Initiative Collaboration group if exists
+            try:
+                _collab_group = self._gis.groups.get(self.collab_group_id)
+                _collab_group.protected = False
+                _collab_group.delete()
+            except:
+                pass
             #Fetch Content Group
             _content_group = self._gis.groups.get(self.content_group_id)
-            #Fetch Followers Group
-            _followers_group = self._gis.groups.get(self.followers_group_id)
-            #Fetch initiative site
+            #Fetch Followers Group for Hub Premium initiatives
+            if self._hub._hub_enabled:
+                _followers_group = self._gis.groups.get(self.followers_group_id)
+            #Disable delete protection on groups
             try:
-                _site = self._hub.sites.get(self.site_id)
-                _site.protected = False
-                _site.delete()
-            except:
-                pass
-            #Disable delete protection on groups and site
-            try:
-                _collab_group.protected = False
                 _content_group.protected = False
                 _followers_group.protected = False
+                _followers_group.delete()
             except:
                 pass
-            #Delete groups, site and initiative
-            _collab_group.delete()
+            #Delete groups and initiative
             _content_group.delete()
-            _followers_group.delete()
             return self.item.delete()
 
     def reassign_to(self, target_owner):
         """
+        
         Allows the administrator to reassign the initiative object from one 
         user to another. 
+        
         .. note::
             This will transfer ownership of all items (site, content) and groups that
             belong to this initiative to the new target_owner.
+        
         =====================     ====================================================================
         **Argument**              **Description**
         ---------------------     --------------------------------------------------------------------
         target_owner              Required string. The new desired owner of the initiative.
         =====================     ====================================================================
         """
-        ###check if admin user is performing this action
+        #check if admin user is performing this action
         if 'admin' not in self._gis.users.me.role:
             return Exception("You do not have the administrator privileges to perform this action.")
-        #fetch the core team for this initiative
-        core_team = self._gis.groups.get(self.collab_group_id)
-        #fetch the contents shared with this team
-        core_team_content = core_team.content()
-        #check if target_owner is part of core team, else add them to core team
-        members = core_team.get_members()
-        if target_owner not in members['admins'] or target_owner not in members['users']:
-            core_team.add_users(target_owner)
-        #remove items from core team 
-        self._gis.content.unshare_items(core_team_content, groups=[core_team])
-        #reassign to target_owner
-        for item in core_team_content:
-            item.reassign_to(target_owner)
-        #fetch the items again since they have been reassigned
-        new_content_list = []
-        for item in core_team_content:
-            item_temp = self._gis.content.get(item.id)
-            new_content_list.append(item_temp)
-        #share item back to the content group
-        self._gis.content.share_items(new_content_list, groups=[core_team], allow_members_to_edit=True)
-        #fetch content and followers teams
+        #check if core team is needed by checking the role of the target_owner
+        if self._gis.users.get(target_owner).role=='org_admin':
+            #check if the initiative comes with core team by checking owner's role
+            if self._gis.users.get(self.owner).role=='org_admin':
+                #fetch the core team for the initative 
+                core_team = self._gis.groups.get(self.collab_group_id)
+                #fetch the contents shared with this team
+                core_team_content = core_team.content()
+                #check if target_owner is part of core team, else add them to core team
+                members = core_team.get_members()
+                if target_owner not in members['admins'] or target_owner not in members['users']:
+                    core_team.add_users(target_owner)
+                #remove items from core team 
+                self._gis.content.unshare_items(core_team_content, groups=[core_team])
+                #reassign to target_owner
+                for item in core_team_content:
+                    item.reassign_to(target_owner)
+                #fetch the items again since they have been reassigned
+                new_content_list = []
+                for item in core_team_content:
+                    item_temp = self._gis.content.get(item.id)
+                    new_content_list.append(item_temp)
+                #share item back to the content group
+                self._gis.content.share_items(new_content_list, groups=[core_team], allow_members_to_edit=True)
+                #reassign core team to target owner
+                core_team.reassign_to(target_owner)
+            else:
+                #create core team necessary for the initiative
+                _collab_group_title = title + ' Core Team'
+                _collab_group_dict = {
+                    "title": _collab_group_title, 
+                    "tags": ["Hub Group", "Hub Initiative Group", "Hub Site Group", "Hub Core Team Group", "Hub Team Group"], 
+                    "access":"org",
+                    "capabilities":"updateitemcontrol",
+                    "membershipAccess": "collaboration",
+                    "snippet": "Members of this group can create, edit, and manage the site, pages, and other content related to hub-groups."
+                }
+                collab_group =  self._gis.groups.create_from_dict(_collab_group_dict)
+                collab_group.protected = True
+                self.collab_group_id = collab_group.id
+        else:
+            #reassign the initiative, site, page items
+            self.item.reassign_to(target_owner)
+            site = self._hub.sites.get(self.site_id)
+            site.item.reassign_to(target_owner)
+            site_pages = site.pages.search()
+            #If pages exist
+            if len(site_pages) > 0:
+                for page in site_pages:
+                    #Unlink page (deletes if)
+                    page.item.reassign_to(target_owner)
+        #fetch content group
         content_team = self._gis.groups.get(self.content_group_id)
-        followers_team = self._gis.groups.get(self.followers_group_id)
-        #reassign them to target_owner
+        #reassign to target_owner
         content_team.reassign_to(target_owner)
-        followers_team.reassign_to(target_owner)
-        core_team.reassign_to(target_owner)
+        #If it is a Hub Premium initiative, repeat for followers group
+        if self._hub._hub_enabled:
+            followers_team = self._gis.groups.get(self.followers_group_id)
+            followers_team.reassign_to(target_owner)
         return self._gis.content.get(self.itemid)
 
     def share(self, everyone=False, org=False, groups=None, allow_members_to_edit=False):
         """
         Shares an initiative and associated site with the specified list of groups.
+        
         ======================  ========================================================
         **Argument**            **Description**
         ----------------------  --------------------------------------------------------
@@ -496,6 +559,7 @@ class Initiative(OrderedDict):
         allow_members_to_edit   Optional boolean. Default is False, to allow item to be
                                 shared with groups that allow shared update
         ======================  ========================================================
+        
         :return:
             A dictionary with key "notSharedWith" containing array of groups with which the items could not be shared.
         """
@@ -508,12 +572,14 @@ class Initiative(OrderedDict):
     def unshare(self, groups):
         """
         Stops sharing of the initiative and its associated site with the specified list of groups.
+        
         ================  =========================================================================================
         **Argument**      **Description**
         ----------------  -----------------------------------------------------------------------------------------
         groups            Optional list of group names as strings, or a list of arcgis.gis.Group objects,
                           or a comma-separated list of group IDs.
         ================  =========================================================================================
+        
         :return:
             Dictionary with key "notUnsharedFrom" containing array of groups from which the items could not be unshared.
         """
@@ -526,10 +592,14 @@ class Initiative(OrderedDict):
 
     def update(self, initiative_properties=None, data=None, thumbnail=None, metadata=None):
         """ Updates the initiative.
+
+
         .. note::
             For initiative_properties, pass in arguments for only the properties you want to be updated.
             All other properties will be untouched.  For example, if you want to update only the
             initiative's description, then only provide the description argument in initiative_properties.
+        
+
         =====================     ====================================================================
         **Argument**              **Description**
         ---------------------     --------------------------------------------------------------------
@@ -541,14 +611,20 @@ class Initiative(OrderedDict):
         ---------------------     --------------------------------------------------------------------
         metadata                  Optional string. Either a path or URL to the metadata.
         =====================     ====================================================================
+        
         To find the list of applicable options for argument initiative_properties - 
         https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.gis.toc.html#arcgis.gis.Item.update
+        
         :return:
            A boolean indicating success (True) or failure (False).
+
         .. code-block:: python
+
             USAGE EXAMPLE: Update an initiative successfully
+
             initiative1 = myHub.initiatives.get('itemId12345')
             initiative1.update(initiative_properties={'description':'Create your own initiative to organize people around a shared goal.'})
+            
             >> True
         """
         if initiative_properties:
@@ -558,15 +634,21 @@ class Initiative(OrderedDict):
                 if key=='title':
                     title = value
                     #Fetch Initiative Collaboration group
-                    _collab_group = self._gis.groups.get(self.collab_group_id)
+                    try:
+                        _collab_group = self._gis.groups.get(self.collab_group_id)
+                        _collab_group.update(title=title+' Core Team')
+                    except:
+                        pass
+                    #Fetch Followers Group
+                    try:
+                        _followers_group = self._gis.groups.get(self.followers_group_id)
+                        _followers_group.update(title=title+' Followers')
+                    except:
+                        pass
                     #Fetch Content Group
                     _content_group = self._gis.groups.get(self.content_group_id)
-                    #Fetch Followers Group
-                    _followers_group = self._gis.groups.get(self.followers_group_id)
-                    #Update title for all groups
-                    _collab_group.update(title=title+' Core Team')
+                    #Update title for group
                     _content_group.update(title=title+' Content')
-                    _followers_group.update(title=title+' Followers')
             return self.item.update(_initiative_data, data, thumbnail, metadata)
     
 class InitiativeManager(object):
@@ -596,52 +678,88 @@ class InitiativeManager(object):
         ---------------     --------------------------------------------------------------------
         thumbnail           Optional string. Either a path or URL to a thumbnail image.
         ===============     ====================================================================
+        
         :return:
            The initiative if successfully added, None if unsuccessful.
+        
         .. code-block:: python
+            
             USAGE EXAMPLE: Add an initiative successfully
+            
             initiative1 = myHub.initiatives.add(title='Vision Zero Analysis')
             initiative1.item
         """
 
         #Define initiative
         if description is None:
-            description = 'Create your own initiative by combining existing applications with a custom site.'
-        _snippet = "Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate."
-        _item_dict = {"type":"Hub Initiative", "snippet":_snippet, "typekeywords":"Hub, hubInitiative, OpenData", "title":title, "description": description, "licenseInfo": "CC-BY-SA","culture": "{{culture}}", "properties":{}}
+            description = (
+                "Create your own initiative by combining existing applications with a custom site."
+            )
+        _snippet = (
+            "Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate."
+        )
+        _item_dict = {
+            "type":"Hub Initiative", 
+            "snippet":_snippet, 
+            "typekeywords":"Hub, hubInitiative, OpenData", 
+            "title":title, 
+            "description": description, 
+            "licenseInfo": "CC-BY-SA",
+            "culture": "{{culture}}", 
+            "properties":{}
+        }
         
         #Defining content, collaboration and followers groups
         _content_group_title = title + ' Content'
-        _content_group_dict = {"title": _content_group_title, "tags": ["Hub Group", "Hub Content Group", "Hub Site Group", "Hub Initiative Group"], "access":"public"}
+        _content_group_dict = {
+            "title": _content_group_title, 
+            "tags": ["Hub Group", "Hub Content Group", "Hub Site Group", "Hub Initiative Group"], 
+            "access":"public"
+        }
         _collab_group_title = title + ' Core Team'
-        _collab_group_dict = {"title": _collab_group_title, "tags": ["Hub Group", "Hub Initiative Group", "Hub Site Group", "Hub Core Team Group", "Hub Team Group"], "access":"org"}
+        _collab_group_dict = {
+            "title": _collab_group_title, 
+            "tags": ["Hub Group", "Hub Initiative Group", "Hub Site Group", "Hub Core Team Group", "Hub Team Group"], 
+            "access":"org",
+            "capabilities":"updateitemcontrol",
+            "membershipAccess": "collaboration",
+            "snippet": "Members of this group can create, edit, and manage the site, pages, and other content related to hub-groups."
+        }
         _followers_group_title = title + ' Followers'
-        _followers_group_dict = {"title": _followers_group_title, "tags": ["Hub Initiative Group", " Hub Initiative Followers Group", "Hub Initiative Group"], "access":"public"}
+        _followers_group_dict = {
+            "title": _followers_group_title, 
+            "tags": ["Hub Group", "Hub Initiative Group", " Hub Initiative Followers Group"], 
+            "access":"public"
+        }
         
         #Create groups
         content_group =  self._gis.groups.create_from_dict(_content_group_dict)
-        collab_group =  self._gis.groups.create_from_dict(_collab_group_dict)
-        followers_group = self._gis.groups.create_from_dict(_followers_group_dict)
-        
         #Protect groups from accidental deletion
         content_group.protected = True
-        collab_group.protected = True
-        followers_group.protected = True
-        
         #Adding it to _item_dict
-        if content_group is not None and collab_group is not None and followers_group is not None:
+        _item_dict['properties']['contentGroupId'] = content_group.id
+        if self._gis.users.me.role=='org_admin':
+            collab_group =  self._gis.groups.create_from_dict(_collab_group_dict)
+            collab_group.protected = True
             _item_dict['properties']['collaborationGroupId'] = collab_group.id
-            _item_dict['properties']['contentGroupId'] = content_group.id
+        if self._hub._hub_enabled:
+            followers_group = self._gis.groups.create_from_dict(_followers_group_dict)
+            followers_group.protected = True
             _item_dict['properties']['followersGroupId'] = followers_group.id
-        
+               
         #Create initiative and share it with collaboration group
         item =  self._gis.content.add(_item_dict, owner=self._gis.users.me.username)
-        item.share(groups=[collab_group])
+        try:
+            item.share(groups=[collab_group])
+        except:
+            pass
 
         #Create initiative site and set initiative properties
         _initiative = Initiative(self._hub, item)
+        #If it is a brand new initiative, create new site
         if site is None:
             site = _initiative.sites.add(title=title)
+        #else clone existing site
         else:
             site = _initiative.sites.clone(site, pages=True, title=title)
         item.update(item_properties={'url': site.url, 'culture': self._gis.properties.user.culture})
@@ -658,6 +776,10 @@ class InitiativeManager(object):
         """
         Clone allows for the creation of an initiative that is derived from the current initiative.
 
+        .. note:: 
+            If both your `origin_hub` and `destination_hub` are Hub Basic organizations, please use the 
+            `clone` method supported under the `~arcgis.apps.sites.SiteManager` class.
+
         ===============     ====================================================================
         **Argument**        **Description**
         ---------------     --------------------------------------------------------------------
@@ -668,14 +790,40 @@ class InitiativeManager(object):
         ---------------     --------------------------------------------------------------------
         title               Optional String.
         ===============     ====================================================================
+        
         :return:
            Initiative.
+
+        .. code-block:: python
+            
+            USAGE EXAMPLE: Clone an initiative in another organization
+
+            #Connect to Hub
+            hub_origin = gis1.hub
+            hub_destination = gis2.hub
+            #Fetch initiative
+            initiative1 = hub_origin.initiatives.get('itemid12345')
+            #Clone in another Hub
+            initiative_cloned = hub_destination.initiatives.clone(initiative1, origin_hub=hub_origin)
+            initiative_cloned.item
+
+
+            USAGE EXAMPLE: Clone initiative in the same organization
+
+            myhub = gis.hub
+            initiative1 = myhub.initiatives.get('itemid12345')
+            initiative2 = myhub.initiatives.clone(initiative1, title='New Initiative')
+
         """
         from datetime import timezone
         now = datetime.now(timezone.utc)
         #Checking if item of correct type has been passed 
         if 'hubInitiative' not in initiative.item.typeKeywords:
             raise Exception("Incorrect item type. Initiative item needed for cloning.")
+        #Checking if initiative or site needs to be cloned
+        if self._hub and origin_hub:
+            if not self._hub._hub_enabled and not origin_hub._hub_enabled:
+                raise Exception("For Hub Basic organizations, please clone the site instead of initiative.")
         #New title
         if title is None:
             title = initiative.title + "-copy-%s" % int(now.timestamp() * 1000)
@@ -713,7 +861,7 @@ class InitiativeManager(object):
             initiative1.item
         """
         initiativeItem =    self._gis.content.get(initiative_id)
-        if 'hubInitiative' in initiativeItem.typeKeywords:
+        if "hubInitiative" in initiativeItem.typeKeywords:
             return Initiative(self._hub, initiativeItem)
         else:
             raise TypeError("Item is not a valid initiative or is inaccessible.")
@@ -1289,7 +1437,11 @@ class Event(OrderedDict):
         self.definition = pmap
             
     def __repr__(self):
-        return '<%s title:"%s" venue:%s>' % (type(self).__name__, self.title, self.venue)
+        return '<%s title:"%s" venue:%s>' % (
+            type(self).__name__, 
+            self.title, 
+            self.venue
+        )
     
     @property 
     def event_id(self):
@@ -1325,13 +1477,6 @@ class Event(OrderedDict):
         Returns the initiative id of the initiative the event belongs to
         """
         return self._eventdict['initiativeId'] 
-    
-    @property
-    def site_id(self):
-        """
-        Returns the site id of the initiative site
-        """
-        return self._eventdict['siteId']
     
     @property
     def organizers(self):
@@ -1415,12 +1560,17 @@ class Event(OrderedDict):
         Allows for adding an image to an event.
         Event should be of type jpeg, jpg or png.
         Max size is 10MB.
+        
         :return:
             A bool containing True (for success) or False (for failure). 
+        
         .. code-block:: python
+        
             USAGE EXAMPLE: Add image to existing event
+        
             event1 = myhub.events.get(24)
             event1.add_attachment(image_url)
+        
             >> True
         """
         url = 'https://hub.arcgis.com/api/v3/events/'+self._hub.enterprise_org_id+'/Hub Events/FeatureServer/0/'+str(self.event_id)+'/addAttachment'
@@ -1430,31 +1580,41 @@ class Event(OrderedDict):
     def delete(self):
         """
         Deletes an event
+        
         :return:
             A bool containing True (for success) or False (for failure). 
+        
         .. code-block:: python
+        
             USAGE EXAMPLE: Delete an event successfully
+        
             event1 = myhub.events.get(24)
             event1.delete()
+        
             >> True
         """
         _group = self._gis.groups.get(self.group_id)
         _group.protected = False
         _group.delete()
-        params = {'f': 'json', 'objectIds': self.event_id}
+        params = {'f': 'json', 'objectIds': self.event_id, 'token': self._gis._con.token}
         delete_event = self._gis._con.post(path='https://hub.arcgis.com/api/v3/events/'+self._hub.enterprise_org_id+'/Hub Events/FeatureServer/0/deleteFeatures', postdata=params)
         return delete_event['deleteResults'][0]['success']
         
     def update(self, event_properties):
         """
         Updates properties of an event
+        
         :return:
             A bool containing True (for success) or False (for failure). 
+        
         .. code-block:: python
+        
             USAGE EXAMPLE: Update an event successfully
+        
             event1 = myhub.events.get(id)
             event_properties = {'status': 'planned', description: 'Test'}
             event1.update(event_properties)
+        
             >> True
         """
         _feature = {}
@@ -1469,7 +1629,11 @@ class Event(OrderedDict):
 
         #Update event
         url = 'https://hub.arcgis.com/api/v3/events/'+self._hub.enterprise_org_id+'/Hub Events/FeatureServer/0/updateFeatures'
-        params = {'f': 'json', 'features': event_data}
+        params = {
+            'f': 'json', 
+            'features': event_data,
+            'token': self._gis._con.token
+        }
         update_event = self._gis._con.post(path=url, postdata=params)
         return update_event['updateResults'][0]['success']
 
@@ -1491,7 +1655,12 @@ class EventManager(object):
         """
         events = []
         url = 'https://hub.arcgis.com/api/v3/events/'+self._hub.enterprise_org_id+'/Hub Events/FeatureServer/0/query'
-        params = {'f' :'json', 'outFields': '*', 'where': '1=1'}
+        params = {
+            'f' :'json', 
+            'outFields': '*', 
+            'where': '1=1',
+            'token': self._gis._con.token
+        }
         all_events = self._gis._con.get(url, params)
         _events_data = all_events['features']
         for event in _events_data:
@@ -1549,7 +1718,9 @@ class EventManager(object):
             Event if successfully added.
 
         .. code-block:: python
+            
             USAGE EXAMPLE: Add an event successfully
+            
             event_properties = {
                 'title':'Test Event',
                 'description': 'Testing with python',
@@ -1561,6 +1732,7 @@ class EventManager(object):
                 'endDate': 1562889600,
                 'isAllDay': 1
             }
+            
             new_event = myhub.events.add(event_properties)
         """
         _feature = {}
@@ -1571,7 +1743,13 @@ class EventManager(object):
         try:
             event_properties['organizers']
         except:
-            _organizers_list = [{"name":self._gis.users.me.fullName, "contact": self._gis.users.me.email, "username": self._gis.users.me.username}]
+            _organizers_list = [
+                {
+                    "name":self._gis.users.me.fullName, 
+                    "contact": self._gis.users.me.email, 
+                    "username": self._gis.users.me.username
+                }
+            ]
             _organizers = json.dumps(_organizers_list)
             event_properties['organizers'] = _organizers
         #Set sponsors if not provided
@@ -1603,7 +1781,11 @@ class EventManager(object):
         event_id = max([event.event_id for event in self._all_events()]) + 1
         
         #Create event group
-        _event_group_dict = {'title': event_properties['title'], 'access': 'public', 'tags': ["Hub Event Group", "Open Data", "hubEvent|"+str(event_id)]}
+        _event_group_dict = {
+            'title': event_properties['title'], 
+            'access': 'public', 
+            'tags': ["Hub Event Group", "Open Data", "hubEvent|"+str(event_id)]
+        }
         _event_group = self._gis.groups.create_from_dict(_event_group_dict)
         _event_group.protected = True
         event_properties['groupId'] = _event_group.id
@@ -1613,7 +1795,11 @@ class EventManager(object):
         _feature["geometry"] = geometry
         event_data = [_feature]
         url = 'https://hub.arcgis.com/api/v3/events/'+self._hub.enterprise_org_id+'/Hub Events/FeatureServer/0/addFeatures'
-        params = {'f': 'json', 'features': event_data}
+        params = {
+            'f': 'json', 
+            'features': event_data,
+            'token': self._gis._con.token
+        }
         add_event = self._gis._con.post(path=url, postdata=params)
         try:
             add_event['addResults']
@@ -1624,6 +1810,7 @@ class EventManager(object):
     def search(self, initiative_id=None, title=None, venue=None, organizer_name=None):
         """ 
         Searches for events within a Hub.
+        
         ===============     ====================================================================
         **Argument**        **Description**
         ---------------     --------------------------------------------------------------------
@@ -1635,8 +1822,10 @@ class EventManager(object):
         ---------------     --------------------------------------------------------------------
         organizer_name      Optional string. Name of the organizer of the event.
         ===============     ====================================================================
+        
         :return:
            A list of matching indicators.
+        
         """
         events = []
         events = self._all_events()
@@ -1653,16 +1842,19 @@ class EventManager(object):
 
     def get(self, event_id):
         """ Get the event for the specified event_id.
+        
         =======================    =============================================================
         **Argument**               **Description**
         -----------------------    -------------------------------------------------------------
         event_id                   Required integer. The event identifier.
         =======================    =============================================================
+        
         :return:
             The event object.
+        
         """
         url = 'https://hub.arcgis.com/api/v3/events/'+self._hub.enterprise_org_id+'/Hub Events/FeatureServer/0/'+str(event_id)
-        params = {'f':'json'}
+        params = {'f':'json', 'token':self._gis._con.token}
         feature = self._gis._con.get(url, params)
         return Event(self._gis, feature['feature'])
 

--- a/arcgishub/sites.py
+++ b/arcgishub/sites.py
@@ -822,18 +822,19 @@ class SiteManager(object):
                 collab_group_id = self.initiative.collab_group_id
             else:
                 #Defining content, collaboration groups for Enterprise Sites
+                collab_group_id = None
                 _content_group_dict = {
-                    "title": subdomain + ' Content', 
-                    "tags": ["Hub Group", "Hub Content Group", "Hub Site Group", "Hub Initiative Group"], 
+                    "title": subdomain + ' Content',
+                    "tags": ["Sites Group", "Sites Content Group"], 
                     "access":"public"
                 }
                 _collab_group_dict = {
                     "title": subdomain + ' Core Team', 
-                    "tags": ["Hub Group", "Hub Initiative Group", "Hub Site Group", "Hub Core Team Group", "Hub Team Group"], 
+                    "tags": ["Sites Group", "Sites Core Team Group"], 
                     "access":"org",
-                    "capabilities":"updateitemcontrol",
-                    "membershipAccess": "collaboration",
-                    "snippet": "Members of this group can create, edit, and manage the site, pages, and other content related to hub-groups."
+                    "capabilities": "updateitemcontrol",
+                    "membershipAccess": "org",
+                    "snippet": "Members of this group can create, edit, and manage the site, pages, and other content related to "+subdomain+"."
                 }
                 #Create groups
                 content_group =  self._gis.groups.create_from_dict(_content_group_dict)
@@ -853,8 +854,8 @@ class SiteManager(object):
                 "description":description,
                 "properties": {
                     'hasSeenGlobalNav': True, 
-                    'createdFrom': 'solutionPortalSiteTemplate', 
-                    'schemaVersion': 1.3, 
+                    'createdFrom': 'portalDefaultSite', 
+                    'schemaVersion': 1.5, 
                     'contentGroupId': content_group_id,
                     'children': []
                 }, 

--- a/examples/For arcgishub library/Site Theme Editing.ipynb
+++ b/examples/For arcgishub library/Site Theme Editing.ipynb
@@ -1,0 +1,282 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2389e062",
+   "metadata": {},
+   "source": [
+    "### Updating the theme of a site\n",
+    "\n",
+    "Editing the layout of a site allows us to add, update, delete the sections, rows, cards of the site and customize the aesthetics of the site.\n",
+    "\n",
+    "Here we see an example to update the theme for a site. While it follows a similar developer experience, it differs in the properties and methods of the site object that are invoked. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b4d9f581",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arcgishub.hub import Hub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b6d10e47",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter password: ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "myhub = Hub(\"https://dcdev.maps.arcgis.com\", \"mmajumdar_dcdev\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cb56c8b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://dcdev.maps.arcgis.com/home/item.html?id=250c204b00b8440abbe0985c3630604e' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACFCAYAAAAenrcsAAAACXBIWXMAAAsSAAALEgHS3X78AAAJ1ElEQVR42u2dT1Bb5xXFj56EeCAhS7YUhJFqQexUOEGjMJ1OmpW8aoeVN93AhuxZOJNdNvaquw7pDHu1C0gTL1xvmMnKZON0VTtV6ulMOoUOtLFBNrIiY2EEZGGpBvTn3Sc9offn/Ga8sPksy1fvvHvPu1ff5wKxFMuf/vqo1c9nfveVi1EyDoUhIKQ5HobAWP77999mAGQBJLrx+l//ucggUyCWFsc9RoIlFmlMliGgQEhzEgwBBUKal1eEAiHMHhQI0Zc9ggAWGAn7wadYnYkiXf11E0CQUaFArHxBH/HjJhSIiVEDH6I/8KuWa55v/p6BogchhAIhhAIhhAIhhAIhhFAghFAgZxxETwBe37sMhA1hH6TKudgnHb/Gqxf/YCCZQQihQAghFAghFAghFAghFAghFAghFAghloCNQoN4tavdJCwX76NcvM9gUSDOYa/0N+wV7+PocI/BoEBIjcODInbzd3Gwv8VgUCDkOAf7W3ix/SWzBk06Oc3R4R7FQYGQZuw+vUtxUCCkEZW9DVT2NhgIehDSiL3iN9KlfwHwBwAPR1O3C0a+B60j2AgF0hUM3LDt49HU7c8YUZZYpJ5VioMCIc35E0NAgZDmrDMEFAhpwmjq9iqjQIEQZg8KhOjmI4aAAiGNM8c1llf2xDF9kNHUbRc/bsIMQggFQggFQggFQggFQggFQggFQggFQgihQAihQAihQAihQMhp1nwq9hWOmFEgpI6XbgWPzvnwKOBjMCgQcppvQ34AwOZgP5729zEgFAipsTnYj6feN6J4FBhkUCgQAgD7iquurCr2efD9EEVCgRA8CvgaGvM1n4qXbn6cRsOdFS3E7OJMZrNFZqn5EsIM4lSyrX741NuH2cWZ6wwTBeLE7HELQEKwdGF2cSbIiFEgThJHAsBN4XI9awkFYv/SqgE3Zhdn0gwbBeKE7HEDQKaNv7rA6HWOmyEwtTiCAO4AUNv464nU9OTz3Erur4wkM4idS6tODPdNGnYKxK7ZIwOg00e2QZZancFZafOWVg8ge6wr4drS/PIqI8sMYhduSMSRfnsKqldkT7IMKU26XbJHGsDnWuvCgQh+9tYl+AeG8HjnB81SKzU96cqt5JhFmEEsj6Zn8Lg9SMYnXl/5viDCgYjUsCcYXgrEytlD1PNIDI/B434zZ5qMT5z4PUstllh2NeaaPY+gP4R3Rn9+8i6nKFAUBc9+fKaprdT05Le5ldw/GXFmEKsh6nlcHrnS8M9j4Tj8A6Jx9yx7IxSI1bJHBoKeR2J4rKUIkrGrkn8uCA4zUiAWK600vYHqVRELx1uu8Q/4NddU4TAjBXImF3d6dnFmrsOXEfU8kvGrIiN+2sDTsNOk9/LOfw/AXGp68j+5ldzDdgQGHT0P0R1PUTCoDmKrsKW1NMphRmaQbnLn2J0/W/URetHV85ASDkQQ9IckSznMSIF0JXvcQn2/4o6eur7dnoeUZEzUGxH5HyfDYUX94rhezR6NKOD1YOBDQXm2Bo3HukF/COnx99t+r+tP1rD+ZE2ylMOMzCDGmHKNO24QwD1BJumo5yElMTwmHmZkqUWBGGHKJRd2S5EY1fMQl1pxUW8kgddP0wgF0jYLAKQeo6FIjOx5SAn6goiGRqSGPcGPmQJpJ3vcADCn99psIBJDex5SLl+8wt4ITXpXfceDDl6iAGCsKgzN1wkHIngvMWn4/2Mzv4F//e97ydKPluaX/8hPngKR+g7Np00CHlaFkmm1yOP24IPkh4ZmjxNv4t8PUCjtiAS9NL9c4BXAEkuLewaIA1XvkpEY826JAxA/FeMwIwUiyh56THnnZtofMsyYN0PnMGOGVwEF0kwccxA+9vzFlV9KnxIZcXfvGB29EW4XBA4rNjPln0Owm2EyPoHzQxcQPhdB+VUZpXKp7Yv2reDw2dwRFQWqV+UwIzNI26b8jsR3REMjJzJHMj7RVmPPyJ6HlHAgwo0eKJC2yELQp/AP+HH5Yn1JlB6f0i0So3se4pJO1htx/M6MFMib7HELghEQj9uD9y6lGl5cHrdHl0jCgQiCvt6MQOnIXNedfGoVBYL/z0eJHm0m4xMtTa5UJO18z6Mbhl0oZseeWqVQHDMJNB9fr7ugJLW7RCTR0EhPSqv6Uusd0X8dDh1mVBwuDrEpDwciSAyPiV9bSySFFzumiIHOYcY0BeIsRM1A1au2VQ61EknpZQmFF+aY5tAxzOg4w+7YPki1GXhLcpGnxtLS5lr9HUhRcH7oAh7v/IDDo8MTPyvvlw1pMnZ8l1QUePu8yBfzmqVWuxtUMINYSxxa3ww8cXft9ItLqldFenyq7i5dKO2YJotEQyPSjR4cZdgVB4ojKDXlp5uBneAf8DcUyeb2hmlio2OYcYECsS/Ht+tpeUEb/Ri2kUjyxW2UX5VNERj/gF/6IGLOKcOMjhJIdUJX84OtmetuXYSnRSLceeRMiIXjHGZ0okmvdoM/k6xNjacx2D/Ytffi7fPi/NAFbD1/gsOjQ5TKJdP0RRRFkZ5aFXXCqVVuh4gjDeF545cvXjmTydrTIqkcVBA+FzFFvFSvitLLEnb3drWWplPTk1/kVnK2/fah4gBxSLfrQTQ0cqaTtcd9Tr64jcpBxTyGXT7MaOuNHpzgQbIQNAObTeh2m3AggmR8ApWDCjbz5nmipXpVqWHP2HmY0dYCqW7XI5rQTcau9swDREMjSMYnsJnfMFUW0XFqlW17I24biyMDwdECAHD10rvSJlkXy60hePu8ePbjs56/l+MMqj7RMdMA1NxK7isKxDq+4xuJKY+F42f+jb5WIoHL1fZYS7dKrcpBBcXdotbSD1LTk3dzK7nHLLHMj2i7nqA/1BPf0fI9+cxXqejYjsh2vRHbZZDZxZksgN9I7ozp8SkoCr8zpnkX1TfMaKuNHhSbiWMOwj10m31tljR/kODEU6sUG4kjLU3x7e5A4nSSMdFsmq2GGd02EUftQM2o5E6o55uB5A21jCsY0U+npie/zq3k1plBzIF4Qtdsptxq6BhmtEWH3fIZpLpdj6bvqE3oevu8vMo7NOzCYcagHYYZXRYXR6sDNU/m/LenTPkI1ap8t55DvrgtWTq2NL9s2VJLsbA4EtI0nhgeoziMNuzxCUecWqVYVBxd266HyA27E4YZrdoIEG3X43F7ED0fNc3GCHbDPzAEj9sjGbDMzi7OrFrx1CrLCUTPgZqVgwq+W8/xSu49tVOrPqZJ7644Oj1Qk/SW95fmly21p5ZiIXHUmoHEuljOsFvJpItMOTE16WqJzBLL4OyxAIfuLm5DLHXMtGIBccxRHLYz7JYptVwmF0caxp1VTszFtaX55VVmkM5MeZbioGHvJT8B3U+Je3ChTHUAAAAASUVORK5CYII=' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://dcdev.maps.arcgis.com/home/item.html?id=250c204b00b8440abbe0985c3630604e' target='_blank'><b>site theme update</b>\n",
+       "                        </a>\n",
+       "                        <br/>Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.<img src='https://dcdev.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Hub Initiative by mmajumdar_dcdev\n",
+       "                        <br/>Last Modified: July 01, 2022\n",
+       "                        <br/>0 comments, 1 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"site theme update\" type:Hub Initiative owner:mmajumdar_dcdev>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i1 = myhub.initiatives.get('250c204b00b8440abbe0985c3630604e')\n",
+    "i1.item"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "592064f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://dcdev.maps.arcgis.com/home/item.html?id=bb0e1cd39ebc45869da35a2e8b91b2d2' target='_blank'>\n",
+       "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://dcdev.maps.arcgis.com/home/item.html?id=bb0e1cd39ebc45869da35a2e8b91b2d2' target='_blank'><b>site theme update</b>\n",
+       "                        </a>\n",
+       "                        <br/>Create your own initiative by combining existing applications with a custom site. Use this initiative to form teams around a problem and invite your community to participate.<img src='https://dcdev.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Hub Site Application by mmajumdar_dcdev\n",
+       "                        <br/>Last Modified: July 01, 2022\n",
+       "                        <br/>0 comments, 5 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"site theme update\" type:Hub Site Application owner:mmajumdar_dcdev>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s1 = myhub.sites.get(i1.site_id)\n",
+    "s1.item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e27e792f",
+   "metadata": {},
+   "source": [
+    "### Fetching theme for site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c8b2a35b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'header': {'background': '#4c4c4c', 'text': '#ffffff'}, 'body': {'background': '#ffffff', 'text': '#5c5c5c', 'link': '#0079c1'}, 'button': {'background': '#0079c1', 'text': '#ffffff'}, 'logo': {'small': 'https://dcdev.maps.arcgis.com/sharing/rest/content/items/a043a0205d644badadb88b7cd9256526/data', 'link': 'https://octo.dc.gov/sites/default/files/dc/sites/octo/multimedia_content/images/OpenData-HeaderLogo-WhiteText-2.png'}, 'fonts': {'base': {'url': '', 'family': 'Avenir Next'}, 'heading': {'url': '', 'family': 'Avenir Next'}}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "theme = s1.theme\n",
+    "theme"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d95b7ddb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'#ffffff'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "theme.body.background"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0abfb390",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'#5c5c5c'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "theme.body.text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caf9bb44",
+   "metadata": {},
+   "source": [
+    "### Updating theme for a site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "561b9b10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "theme.body.background = '#c90076'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d54cdaad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "theme.body.text = '#eeeeee'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8c2d659d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s1.update_theme(theme)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6260e30a",
+   "metadata": {},
+   "source": [
+    "By refreshing this site, we then see the theme color of the site has been updated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08f35abe",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Change implemented as a `subdomain` parameter in `site.update()`. E.g. usage `site1.update(subdomain='my new site')`
 
Works with Hub Premium, Hub Basic and Enterprise sites.
